### PR TITLE
Added support for CRL check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+  - Add support for CRL to check for the server certificate is revocation status.
+
 ## 3.0.5
   - Docs: Set the default_codec doc attribute.
 
@@ -37,4 +40,3 @@
  - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully,
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0
-

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -58,6 +58,8 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-ssl_key>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-ssl_key_passphrase>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-ssl_verify>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-ssl_crl>> |a valid filesystem path|No
+| <<plugins-{type}s-{plugin}-ssl_crl_check_all>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-use_labels>> |<<boolean,boolean>>|No
 |=======================================================================
 
@@ -224,6 +226,24 @@ SSL key passphrase
   * Default value is `false`
 
 Verify the identity of the other end of the SSL connection against the CA.
+
+[id="plugins-{type}s-{plugin}-ssl_crl"]
+===== `ssl_crl`
+
+  * Value type is <<path,path>>
+  * There is no default value for this setting.
+
+SSL CRL path for checking the revocation status of the server certificate.
+File may contain one or more PEM encoded CRLs.
+
+[id="plugins-{type}s-{plugin}-ssl_crl_check_all"]
+===== `ssl_crl_check_all`
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `false`
+
+If this option is set to false, only the certificate at the end of the certificate chain will be subject to validation by CRL.
+If set to true the complete chain is validated. CRLs must be available from all CAs.
 
 [id="plugins-{type}s-{plugin}-use_labels"]
 ===== `use_labels` 

--- a/lib/logstash/outputs/syslog.rb
+++ b/lib/logstash/outputs/syslog.rb
@@ -81,6 +81,12 @@ class LogStash::Outputs::Syslog < LogStash::Outputs::Base
   # SSL key passphrase
   config :ssl_key_passphrase, :validate => :password, :default => nil
 
+  # CRL file or bundle of CRLs
+  config :ssl_crl, :validate => :path
+
+  # Check CRL for only leaf certificate (false) or require CRL check for the complete chain (true)
+  config :ssl_crl_check_all, :validate => :boolean, :default => false
+
   # use label parsing for severity and facility levels
   # use priority field if set to false
   config :use_labels, :validate => :boolean, :default => true
@@ -131,7 +137,7 @@ class LogStash::Outputs::Syslog < LogStash::Outputs::Base
     if ssl?
       @ssl_context = setup_ssl
     end
-    
+
     if @codec.instance_of? LogStash::Codecs::Plain
       if @codec.config["format"].nil?
         @codec = LogStash::Codecs::Plain.new({"format" => @message})
@@ -223,6 +229,8 @@ class LogStash::Outputs::Syslog < LogStash::Outputs::Base
     socket
   end
 
+  CRL_END_TAG = "\n-----END X509 CRL-----\n"
+
   def setup_ssl
     require "openssl"
     ssl_context = OpenSSL::SSL::SSLContext.new
@@ -236,6 +244,14 @@ class LogStash::Outputs::Syslog < LogStash::Outputs::Base
         cert_store.add_path(@ssl_cacert)
       else
         cert_store.add_file(@ssl_cacert)
+      end
+      if @ssl_crl
+        # copy the behavior of X509_load_crl_file() which supports loading bundles of CRLs.
+        File.read(@ssl_crl).split(CRL_END_TAG).each do |crl|
+          crl << CRL_END_TAG
+          cert_store.add_crl(OpenSSL::X509::CRL.new(crl))
+        end
+        cert_store.flags = @ssl_crl_check_all ? OpenSSL::X509::V_FLAG_CRL_CHECK|OpenSSL::X509::V_FLAG_CRL_CHECK_ALL : OpenSSL::X509::V_FLAG_CRL_CHECK
       end
       ssl_context.cert_store = cert_store
       ssl_context.verify_mode = OpenSSL::SSL::VERIFY_PEER|OpenSSL::SSL::VERIFY_FAIL_IF_NO_PEER_CERT


### PR DESCRIPTION
This change adds support for CRL (Certificate Revocation List) check, to validate that the certificate of the syslog server has not been revoked. The CRL is loaded from file, meaning it must be pre-loaded on the system where logstash is executing.

The change adds two new configuration options
* `ssl_crl` path to CRL file for checking the revocation status of the server certificate. The file may contain one or more PEM encoded CRLs.
* `ssl_crl_check_all`  If this option is set to `false`, only the certificate at the end of the certificate chain will be subject to validation by CRL. If set to `true` the complete chain is validated. CRLs must be available from all CAs. Default value is `false`

This PR was submitted to the upstream https://www.github.com/logstash-plugins/logstash-output-syslog/pull/62