### PR TITLE
Allow PKCS8 EC private keys to be loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+  - Support loading of PKCS8 EC private keys.
+
 ## 3.0.5
   - Docs: Set the default_codec doc attribute.
 
@@ -37,4 +40,3 @@
  - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully,
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0
-

--- a/lib/logstash/outputs/syslog.rb
+++ b/lib/logstash/outputs/syslog.rb
@@ -227,7 +227,7 @@ class LogStash::Outputs::Syslog < LogStash::Outputs::Base
     require "openssl"
     ssl_context = OpenSSL::SSL::SSLContext.new
     ssl_context.cert = OpenSSL::X509::Certificate.new(File.read(@ssl_cert))
-    ssl_context.key = OpenSSL::PKey::RSA.new(File.read(@ssl_key),@ssl_key_passphrase)
+    ssl_context.key = OpenSSL::PKey::read(File.read(@ssl_key),@ssl_key_passphrase)
     if @ssl_verify
       cert_store = OpenSSL::X509::Store.new
       # Load the system default certificate path to the store


### PR DESCRIPTION
This change makes it possible to use EC (elliptic curve) private keys as client credentials.

Depends on [jruby-openssl 0.14.1](https://github.com/jruby/jruby-openssl/releases/tag/v0.14.1) or later. Without that version, this change has no effect.

This PR was submitted to upstream https://www.github.com/logstash-plugins/logstash-output-syslog/pull/61