### PR TITLE
Added support for TLS SNI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+  - The SNI (Server Name Indication) extension is now used when connecting to syslog server with TLS and `host` is set to FQDN (Fully Qualified Domain Name).
+
 ## 3.0.5
   - Docs: Set the default_codec doc attribute.
 
@@ -37,4 +40,3 @@
  - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully,
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0
-

--- a/lib/logstash/outputs/syslog.rb
+++ b/lib/logstash/outputs/syslog.rb
@@ -209,6 +209,8 @@ class LogStash::Outputs::Syslog < LogStash::Outputs::Base
       socket = TCPSocket.new(@host, @port)
       if ssl?
         socket = OpenSSL::SSL::SSLSocket.new(socket, @ssl_context)
+        # Use SNI extension
+        socket.hostname = @host
         begin
           socket.connect
         rescue OpenSSL::SSL::SSLError => ssle


### PR DESCRIPTION
When TLS is used to connect to the syslog server, this change adds the TLS SNI extension to the TLS handshake, to indicate the wanted server name to the server.  

Note that the `host` configuration option needs to be set to FQDN (Fully Qualified Domain Name) and not e.g. IP address or hostname without domain part.