### PR TITLE
Added support for RFC5424 structured data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+  - Added support for RFC5424 structured data.
+
 ## 3.0.5
   - Docs: Set the default_codec doc attribute.
 
@@ -37,4 +40,3 @@
  - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully,
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0
-

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -59,6 +59,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-ssl_key_passphrase>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-ssl_verify>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-use_labels>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-structured_data>> |<<string,string>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
@@ -234,7 +235,19 @@ Verify the identity of the other end of the SSL connection against the CA.
 use label parsing for severity and facility levels
 use priority field if set to false
 
+[id="plugins-{type}s-{plugin}-structured_data"]
+===== `structured_data`
 
+  * Value type is <<string,string>>
+  * Default value is `nil`
+
+RFC5424 structured data is a string of one or more structured data elements, including brackets.
+The elements need to be formatted according to link:https://datatracker.ietf.org/doc/html/rfc5424#section-6.3[RFC5424 section 6.3], for example:
+
+[source,ruby]
+   `[exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"][examplePriority@32473 class="high"]`
+
+The new value can include `%{foo}` strings to help you build a new value from other parts of the event.
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/lib/logstash/outputs/syslog.rb
+++ b/lib/logstash/outputs/syslog.rb
@@ -125,13 +125,16 @@ class LogStash::Outputs::Syslog < LogStash::Outputs::Base
   # syslog message format: you can choose between rfc3164 or rfc5424
   config :rfc, :validate => ["rfc3164", "rfc5424"], :default => "rfc3164"
 
+  # RFC5424 structured data.
+  config :structured_data, :validate => :string, :default => nil
+
   def register
     @client_socket = nil
 
     if ssl?
       @ssl_context = setup_ssl
     end
-    
+
     if @codec.instance_of? LogStash::Codecs::Plain
       if @codec.config["format"].nil?
         @codec = LogStash::Codecs::Plain.new({"format" => @message})
@@ -141,6 +144,11 @@ class LogStash::Outputs::Syslog < LogStash::Outputs::Base
 
     # use instance variable to avoid string comparison for each event
     @is_rfc3164 = (@rfc == "rfc3164")
+
+    if @is_rfc3164 && !@structured_data.nil?
+      raise LogStash::ConfigurationError, "Structured data is not supported for RFC3164"
+    end
+
   end
 
   def receive(event)
@@ -169,8 +177,9 @@ class LogStash::Outputs::Syslog < LogStash::Outputs::Base
       syslog_msg = "<#{priority.to_s}>#{timestamp} #{sourcehost} #{appname}[#{procid}]: #{message}"
     else
       msgid = event.sprintf(@msgid)
+      sd = @structured_data.nil? ? "-" : event.sprintf(@structured_data)
       timestamp = event.sprintf("%{+YYYY-MM-dd'T'HH:mm:ss.SSSZZ}")
-      syslog_msg = "<#{priority.to_s}>1 #{timestamp} #{sourcehost} #{appname} #{procid} #{msgid} - #{message}"
+      syslog_msg = "<#{priority.to_s}>1 #{timestamp} #{sourcehost} #{appname} #{procid} #{msgid} #{sd} #{message}"
     end
 
     begin


### PR DESCRIPTION
This PR adds support for RFC5424 structured data.

The is the same feature as submitted in [logstash-plugins#1](https://www.github.com/logstash-plugins/logstash-output-syslog/pull/1) but since the author did not sign CLA, the implementation is new and not based on the same work.
